### PR TITLE
Add df_filter to view raw data

### DIFF
--- a/src/anndata_mcp/tools/_view.py
+++ b/src/anndata_mcp/tools/_view.py
@@ -102,13 +102,13 @@ def view_raw_data(
 
         attr_obj = getattr(adata, attribute, None)
         if attr_obj is None:
-            raise ValueError(f"Attribute {attribute} not found")
+            raise KeyError(f"Attribute {attribute} not found")
         
         if key is not None:
             try:
                 attr_obj = attr_obj[key]
             except KeyError:
-                raise ValueError(f"Attribute {attribute} with key {key} not found")
+                raise KeyError(f"Attribute {attribute} with key {key} not found")
 
         # Apply df_filter if provided - filters only the dataframe being viewed, not the whole AnnData
         # This allows showing specific parts of any dataframe attribute (e.g., filtered rows of obs or var)

--- a/src/anndata_mcp/tools/_view.py
+++ b/src/anndata_mcp/tools/_view.py
@@ -100,7 +100,9 @@ def view_raw_data(
         adata = read_lazy_general(path)
 
         attr_obj = getattr(adata, attribute, None)
-        if key is not None and attr_obj is not None:
+        if attr_obj is None:
+            error = f"Attribute {attribute} not found"
+        elif key is not None:
             try:
                 attr_obj = attr_obj[key]
             except KeyError:
@@ -131,7 +133,7 @@ def view_raw_data(
                         data, slice_shape = extract_data_from_dataset2d(
                             attr_obj, selected_columns, row_slice, index=True, return_shape=True
                         )
-                    full_shape = str(attr_obj.shape)
+                        full_shape = str(attr_obj.shape)
                 elif isinstance(attr_obj, Array):
                     if attribute in ("X", "layers") and columns_or_genes is not None:
                         # Convert gene names to indices for X and layers

--- a/src/anndata_mcp/tools/_view.py
+++ b/src/anndata_mcp/tools/_view.py
@@ -82,7 +82,7 @@ def view_raw_data(
             Annotated[list[str | float | bool] | str | float | bool, Field(description="The value(s) to filter by")],
         ]
         | None,
-        Field(description="A filter to apply to the selected dataframe. Only applicable when the attribute is a Dataset2D (e.g., obs, var)."),
+        Field(description="A filter to apply to the selected dataframe. Only applicable when the attribute is a dataframe or dataframe-like (e.g., obs, var)."),
     ] = None,
 ) -> DataView:
     """View the data of an AnnData object."""
@@ -110,7 +110,7 @@ def view_raw_data(
                     attr_obj = attr_obj[mask]  # Filter only this Dataset2D, not the whole AnnData
                 else:
                     adata.file.close()
-                    error = f"df_filter can only be applied to Dataset2D attributes (e.g., obs, var), but {attribute} is of type {extract_original_type_string(attr_obj, full_name=True)}"
+                    error = f"df_filter can only be applied to dataframe or dataframe-like attributes (e.g., obs, var), but {attribute} is of type {extract_original_type_string(attr_obj, full_name=True)}"
 
             slice_shape = None
             full_shape = None

--- a/src/anndata_mcp/tools/_view.py
+++ b/src/anndata_mcp/tools/_view.py
@@ -114,7 +114,7 @@ def view_raw_data(
                     mask = create_dataframe_mask_from_tuple(attr_obj, df_filter)
                     attr_obj = attr_obj[mask]  # Filter only this dataframe, not the whole AnnData
                 else:
-                    error = f"df_filter can only be applied to dataframe or dataframe-like attributes (e.g., obs, var), but {attribute} is of type {extract_original_type_string(attr_obj, full_name=True)}"
+                    error = f"df_filter can only be applied to dataframe or dataframe-like attributes (e.g., obs, var)"
 
             if error is None:
                 if isinstance(attr_obj, Dataset2D):

--- a/src/anndata_mcp/tools/_view.py
+++ b/src/anndata_mcp/tools/_view.py
@@ -102,11 +102,12 @@ def view_raw_data(
                 error = f"Attribute {attribute} with key {key} not found"
 
         if error is None:
-            # Apply df_filter if provided - only works on Dataset2D attributes
+            # Apply df_filter if provided - filters only the Dataset2D object being viewed, not the whole AnnData
+            # This allows showing specific parts of any Dataset2D attribute (e.g., filtered rows of obs or var)
             if df_filter is not None:
                 if isinstance(attr_obj, Dataset2D):
                     mask = create_dataframe_mask_from_tuple(attr_obj, df_filter)
-                    attr_obj = attr_obj[mask]
+                    attr_obj = attr_obj[mask]  # Filter only this Dataset2D, not the whole AnnData
                 else:
                     adata.file.close()
                     error = f"df_filter can only be applied to Dataset2D attributes (e.g., obs, var), but {attribute} is of type {extract_original_type_string(attr_obj, full_name=True)}"

--- a/src/anndata_mcp/tools/_view.py
+++ b/src/anndata_mcp/tools/_view.py
@@ -102,76 +102,76 @@ def view_raw_data(
 
         attr_obj = getattr(adata, attribute, None)
         if attr_obj is None:
-            error = f"Attribute {attribute} not found"
-        elif key is not None:
+            raise ValueError(f"Attribute {attribute} not found")
+        
+        if key is not None:
             try:
                 attr_obj = attr_obj[key]
             except KeyError:
-                error = f"Attribute {attribute} with key {key} not found"
+                raise ValueError(f"Attribute {attribute} with key {key} not found")
 
-        if error is None:
-            # Apply df_filter if provided - filters only the dataframe being viewed, not the whole AnnData
-            # This allows showing specific parts of any dataframe attribute (e.g., filtered rows of obs or var)
-            if df_filter is not None:
-                if isinstance(attr_obj, Dataset2D):
-                    mask = create_dataframe_mask_from_tuple(attr_obj, df_filter)
-                    # Convert mask to numpy boolean array, then to integer indices for Dataset2D indexing
-                    if hasattr(mask, 'compute'):
-                        mask = mask.compute()
-                    if hasattr(mask, 'values'):
-                        mask_bool = np.asarray(mask.values, dtype=bool)
-                    else:
-                        mask_bool = np.asarray(mask, dtype=bool)
-                    # Convert boolean mask to integer indices for .iloc indexing
-                    indices = np.where(mask_bool)[0]
-                    attr_obj = attr_obj.iloc[indices]  # Filter only this dataframe, not the whole AnnData
+        # Apply df_filter if provided - filters only the dataframe being viewed, not the whole AnnData
+        # This allows showing specific parts of any dataframe attribute (e.g., filtered rows of obs or var)
+        if df_filter is not None:
+            if isinstance(attr_obj, Dataset2D):
+                mask = create_dataframe_mask_from_tuple(attr_obj, df_filter)
+                # Convert mask to numpy boolean array, then to integer indices for Dataset2D indexing
+                if hasattr(mask, 'compute'):
+                    mask = mask.compute()
+                if hasattr(mask, 'values'):
+                    mask_bool = np.asarray(mask.values, dtype=bool)
                 else:
-                    error = f"df_filter can only be applied to dataframe or dataframe-like attributes (e.g., obs, var)"
+                    mask_bool = np.asarray(mask, dtype=bool)
+                # Convert boolean mask to integer indices for .iloc indexing
+                indices = np.where(mask_bool)[0]
+                attr_obj = attr_obj.iloc[indices]  # Filter only this dataframe, not the whole AnnData
+            else:
+                raise ValueError(f"df_filter can only be applied to dataframe or dataframe-like attributes (e.g., obs, var)")
 
-            if error is None:
-                if isinstance(attr_obj, Dataset2D):
-                    # Use columns_or_genes as column names for dataframe, or all columns if None
-                    available_columns = attr_obj.columns.tolist()
-                    selected_columns = (
-                        match_patterns(available_columns, columns_or_genes)[0]
-                        if columns_or_genes is not None
-                        else available_columns
-                    )
-                    if len(selected_columns) == 0:
-                        error = "None of the provided columns were found in the attribute"
-                    else:
-                        data, slice_shape = extract_data_from_dataset2d(
-                            attr_obj, selected_columns, row_slice, index=True, return_shape=True
-                        )
-                        full_shape = str(attr_obj.shape)
-                elif isinstance(attr_obj, Array):
-                    if attribute in ("X", "layers") and columns_or_genes is not None:
-                        # Convert gene names to indices for X and layers
-                        var_names = adata.var_names.tolist()
-                        columns_or_genes, _ = match_patterns(var_names, columns_or_genes)
-                        if len(columns_or_genes) == 0:
-                            error = "None of the provided genes were found in var_names"
-                        else:
-                            gene_indices = [var_names.index(gene) for gene in columns_or_genes]
-                            data, slice_shape = extract_data_from_dask_array_with_indices(
-                                attr_obj, row_slice, gene_indices, return_shape=True
-                            )
-                    else:
-                        data, slice_shape = extract_data_from_dask_array(attr_obj, row_slice, col_slice, return_shape=True)
-                    full_shape = str(attr_obj.shape)
-                else:
-                    data = (
-                        "Entries: "
-                        + ", ".join(
-                            [
-                                f"{key}: {extract_original_type_string(attr_obj[key], full_name=True)} {get_shape_str(attr_obj[key])}"
-                                for key in attr_obj.keys()
-                            ]
-                        )
-                        if hasattr(attr_obj, "keys")
-                        else str(attr_obj)
-                    )
-                data_type = extract_original_type_string(attr_obj, full_name=True) if error is None else None
+        if isinstance(attr_obj, Dataset2D):
+            # Use columns_or_genes as column names for dataframe, or all columns if None
+            available_columns = attr_obj.columns.tolist()
+            selected_columns = (
+                match_patterns(available_columns, columns_or_genes)[0]
+                if columns_or_genes is not None
+                else available_columns
+            )
+            if len(selected_columns) == 0:
+                raise ValueError("None of the provided columns were found in the attribute")
+            
+            data, slice_shape = extract_data_from_dataset2d(
+                attr_obj, selected_columns, row_slice, index=True, return_shape=True
+            )
+            full_shape = str(attr_obj.shape)
+        elif isinstance(attr_obj, Array):
+            if attribute in ("X", "layers") and columns_or_genes is not None:
+                # Convert gene names to indices for X and layers
+                var_names = adata.var_names.tolist()
+                columns_or_genes, _ = match_patterns(var_names, columns_or_genes)
+                if len(columns_or_genes) == 0:
+                    raise ValueError("None of the provided genes were found in var_names")
+                
+                gene_indices = [var_names.index(gene) for gene in columns_or_genes]
+                data, slice_shape = extract_data_from_dask_array_with_indices(
+                    attr_obj, row_slice, gene_indices, return_shape=True
+                )
+            else:
+                data, slice_shape = extract_data_from_dask_array(attr_obj, row_slice, col_slice, return_shape=True)
+            full_shape = str(attr_obj.shape)
+        else:
+            data = (
+                "Entries: "
+                + ", ".join(
+                    [
+                        f"{key}: {extract_original_type_string(attr_obj[key], full_name=True)} {get_shape_str(attr_obj[key])}"
+                        for key in attr_obj.keys()
+                    ]
+                )
+                if hasattr(attr_obj, "keys")
+                else str(attr_obj)
+            )
+        
+        data_type = extract_original_type_string(attr_obj, full_name=True)
 
     except Exception as e:  # noqa: BLE001
         # Catch all exceptions to ensure function always returns DataView

--- a/src/anndata_mcp/tools/_view.py
+++ b/src/anndata_mcp/tools/_view.py
@@ -86,8 +86,14 @@ def view_raw_data(
     ] = None,
 ) -> DataView:
     """View the data of an AnnData object."""
+    error = None
+    data = None
+    data_type = None
+    slice_shape = None
+    full_shape = None
+    adata = None
+
     try:
-        error = None
         row_slice = slice(row_start_index, row_stop_index, None)
         col_slice = slice(col_start_index, col_stop_index, None)
 
@@ -98,74 +104,71 @@ def view_raw_data(
             try:
                 attr_obj = attr_obj[key]
             except KeyError:
-                adata.file.close()
                 error = f"Attribute {attribute} with key {key} not found"
 
         if error is None:
-            # Apply df_filter if provided - filters only the Dataset2D object being viewed, not the whole AnnData
-            # This allows showing specific parts of any Dataset2D attribute (e.g., filtered rows of obs or var)
+            # Apply df_filter if provided - filters only the dataframe being viewed, not the whole AnnData
+            # This allows showing specific parts of any dataframe attribute (e.g., filtered rows of obs or var)
             if df_filter is not None:
                 if isinstance(attr_obj, Dataset2D):
                     mask = create_dataframe_mask_from_tuple(attr_obj, df_filter)
-                    attr_obj = attr_obj[mask]  # Filter only this Dataset2D, not the whole AnnData
+                    attr_obj = attr_obj[mask]  # Filter only this dataframe, not the whole AnnData
                 else:
-                    adata.file.close()
                     error = f"df_filter can only be applied to dataframe or dataframe-like attributes (e.g., obs, var), but {attribute} is of type {extract_original_type_string(attr_obj, full_name=True)}"
 
-            slice_shape = None
-            full_shape = None
-            if error is None and isinstance(attr_obj, Dataset2D):
-                # Use columns_or_genes as column names for Dataset2D, or all columns if None
-                available_columns = attr_obj.columns.tolist()
-                selected_columns = (
-                    match_patterns(available_columns, columns_or_genes)[0]
-                    if columns_or_genes is not None
-                    else available_columns
-                )
-                if len(selected_columns) == 0:
-                    error = "None of the provided columns were found in the attribute"
-                else:
-                    data, slice_shape = extract_data_from_dataset2d(
-                        attr_obj, selected_columns, row_slice, index=True, return_shape=True
+            if error is None:
+                if isinstance(attr_obj, Dataset2D):
+                    # Use columns_or_genes as column names for dataframe, or all columns if None
+                    available_columns = attr_obj.columns.tolist()
+                    selected_columns = (
+                        match_patterns(available_columns, columns_or_genes)[0]
+                        if columns_or_genes is not None
+                        else available_columns
                     )
-                full_shape = str(attr_obj.shape)
-            elif isinstance(attr_obj, Array):
-                if attribute in ("X", "layers") and columns_or_genes is not None:
-                    # Convert gene names to indices for X and layers
-                    var_names = adata.var_names.tolist()
-                    columns_or_genes, _ = match_patterns(var_names, columns_or_genes)
-                    if len(columns_or_genes) == 0:
-                        error = "None of the provided genes were found in var_names"
+                    if len(selected_columns) == 0:
+                        error = "None of the provided columns were found in the attribute"
                     else:
-                        gene_indices = [var_names.index(gene) for gene in columns_or_genes]
-                        data, slice_shape = extract_data_from_dask_array_with_indices(
-                            attr_obj, row_slice, gene_indices, return_shape=True
+                        data, slice_shape = extract_data_from_dataset2d(
+                            attr_obj, selected_columns, row_slice, index=True, return_shape=True
                         )
+                    full_shape = str(attr_obj.shape)
+                elif isinstance(attr_obj, Array):
+                    if attribute in ("X", "layers") and columns_or_genes is not None:
+                        # Convert gene names to indices for X and layers
+                        var_names = adata.var_names.tolist()
+                        columns_or_genes, _ = match_patterns(var_names, columns_or_genes)
+                        if len(columns_or_genes) == 0:
+                            error = "None of the provided genes were found in var_names"
+                        else:
+                            gene_indices = [var_names.index(gene) for gene in columns_or_genes]
+                            data, slice_shape = extract_data_from_dask_array_with_indices(
+                                attr_obj, row_slice, gene_indices, return_shape=True
+                            )
+                    else:
+                        data, slice_shape = extract_data_from_dask_array(attr_obj, row_slice, col_slice, return_shape=True)
+                    full_shape = str(attr_obj.shape)
                 else:
-                    data, slice_shape = extract_data_from_dask_array(attr_obj, row_slice, col_slice, return_shape=True)
-                full_shape = str(attr_obj.shape)
-            else:
-                data = (
-                    "Entries: "
-                    + ", ".join(
-                        [
-                            f"{key}: {extract_original_type_string(attr_obj[key], full_name=True)} {get_shape_str(attr_obj[key])}"
-                            for key in attr_obj.keys()
-                        ]
+                    data = (
+                        "Entries: "
+                        + ", ".join(
+                            [
+                                f"{key}: {extract_original_type_string(attr_obj[key], full_name=True)} {get_shape_str(attr_obj[key])}"
+                                for key in attr_obj.keys()
+                            ]
+                        )
+                        if hasattr(attr_obj, "keys")
+                        else str(attr_obj)
                     )
-                    if hasattr(attr_obj, "keys")
-                    else str(attr_obj)
-                )
-            attr_obj_type = extract_original_type_string(attr_obj, full_name=True)
-            result = DataView(data=data, data_type=attr_obj_type, slice_shape=slice_shape, full_shape=full_shape)
-        else:
-            result = DataView(error=error)
-        adata.file.close()
-        del adata
-        gc.collect()
+                data_type = extract_original_type_string(attr_obj, full_name=True) if error is None else None
+
     except Exception as e:  # noqa: BLE001
         # Catch all exceptions to ensure function always returns DataView
         # This is intentional for API stability - all errors are returned in the error field
         error = truncate_string(str(e), max_output_len=100)
-        result = DataView(error=error)
-    return result
+    finally:
+        if adata is not None:
+            adata.file.close()
+            del adata
+            gc.collect()
+
+    return DataView(data=data, data_type=data_type, slice_shape=slice_shape, full_shape=full_shape, error=error)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -505,12 +505,12 @@ class TestViewRawData:
         assert result.data is not None
 
     def test_view_raw_data_with_df_filter_and_X_attribute(self, test_h5ad_path):
-        """Test view_raw_data with df_filter applied to X attribute - should error since X is not Dataset2D."""
+        """Test view_raw_data with df_filter applied to X attribute - should error since X is not a dataframe."""
         result = view_raw_data(str(test_h5ad_path), attribute="X", df_filter=("n_genes", ">", 30))
 
         assert isinstance(result, DataView)
         assert result.error is not None
-        assert "df_filter can only be applied to Dataset2D" in result.error.lower() or "dataset2d" in result.error.lower()
+        assert "df_filter can only be applied to dataframe" in result.error.lower() or "dataframe-like" in result.error.lower()
 
     def test_view_raw_data_with_df_filter_var(self, test_h5ad_path):
         """Test view_raw_data with df_filter applied to var attribute."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -505,8 +505,16 @@ class TestViewRawData:
         assert result.data is not None
 
     def test_view_raw_data_with_df_filter_and_X_attribute(self, test_h5ad_path):
-        """Test view_raw_data with df_filter applied to X attribute."""
+        """Test view_raw_data with df_filter applied to X attribute - should error since X is not Dataset2D."""
         result = view_raw_data(str(test_h5ad_path), attribute="X", df_filter=("n_genes", ">", 30))
+
+        assert isinstance(result, DataView)
+        assert result.error is not None
+        assert "df_filter can only be applied to Dataset2D" in result.error.lower() or "dataset2d" in result.error.lower()
+
+    def test_view_raw_data_with_df_filter_var(self, test_h5ad_path):
+        """Test view_raw_data with df_filter applied to var attribute."""
+        result = view_raw_data(str(test_h5ad_path), attribute="var", df_filter=("n_cells", ">", 0))
 
         assert isinstance(result, DataView)
         assert result.error is None

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -487,6 +487,49 @@ class TestViewRawData:
             keyword in error_lower for keyword in ["file", "not found", "no such file", "cannot find", "does not exist"]
         )
 
+    def test_view_raw_data_with_df_filter_equals(self, test_h5ad_path):
+        """Test view_raw_data with df_filter using == operator."""
+        result = view_raw_data(str(test_h5ad_path), attribute="obs", df_filter=("cell_type", "==", "TypeA"))
+
+        assert isinstance(result, DataView)
+        assert result.error is None
+        assert result.data is not None
+        assert result.data_type is not None
+
+    def test_view_raw_data_with_df_filter_greater_than(self, test_h5ad_path):
+        """Test view_raw_data with df_filter using > operator."""
+        result = view_raw_data(str(test_h5ad_path), attribute="obs", df_filter=("n_genes", ">", 30))
+
+        assert isinstance(result, DataView)
+        assert result.error is None
+        assert result.data is not None
+
+    def test_view_raw_data_with_df_filter_and_X_attribute(self, test_h5ad_path):
+        """Test view_raw_data with df_filter applied to X attribute."""
+        result = view_raw_data(str(test_h5ad_path), attribute="X", df_filter=("n_genes", ">", 30))
+
+        assert isinstance(result, DataView)
+        assert result.error is None
+        assert result.data is not None
+
+    def test_view_raw_data_with_df_filter_isin(self, test_h5ad_path):
+        """Test view_raw_data with df_filter using isin operator."""
+        result = view_raw_data(
+            str(test_h5ad_path), attribute="obs", df_filter=("cell_type", "isin", ["TypeA", "TypeB"])
+        )
+
+        assert isinstance(result, DataView)
+        assert result.error is None
+        assert result.data is not None
+
+    def test_view_raw_data_with_df_filter_invalid_column(self, test_h5ad_path):
+        """Test view_raw_data with df_filter using invalid column name."""
+        result = view_raw_data(str(test_h5ad_path), attribute="obs", df_filter=("nonexistent_column", "==", "value"))
+
+        assert isinstance(result, DataView)
+        assert result.error is not None
+        assert "not found" in result.error.lower() or "column" in result.error.lower()
+
 
 class TestLocateAnndataStores:
     """Tests for locate_anndata_stores tool."""


### PR DESCRIPTION
Add `df_filter` argument to `view_raw_data` to enable filtering of the `obs` DataFrame, consistent with `obs_filter` in `get_descriptive_stats`.

---
<a href="https://cursor.com/background-agent?bcId=bc-18238636-1177-495f-947d-6033bb1b51a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-18238636-1177-495f-947d-6033bb1b51a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add row-level dataframe filtering and nested key access to `view_raw_data`, with supporting util and tests.
> 
> - **Tools (`src/anndata_mcp/tools/_view.py`)**:
>   - Add `df_filter` to `view_raw_data` for row filtering on dataframe-like attributes (`Dataset2D` such as `obs`/`var`) using operators `==`, `!=`, `>`, `>=`, `<`, `<=`, `isin`, `notin`.
>   - Support nested `key` paths (`str` or `list[str]`) via `get_nested_key`; improve attribute/key error messages.
>   - Apply mask-to-index filtering, preserve column selection logic, and return `data_type`, `slice_shape`, `full_shape`; ensure file handles are closed in `finally`.
> - **Utils (`src/anndata_mcp/tools/utils.py`)**:
>   - Add `get_nested_key` helper for traversing nested dict/attribute/indexable structures.
> - **Tests (`tests/test_tools.py`)**:
>   - Add comprehensive tests for `df_filter` (equality, inequalities, `isin`/`notin`, invalid column) and behavior on non-dataframe attributes.
>   - Keep existing coverage for `view_raw_data` and other tools.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 751fcee8c7e0c7899ae172f1e00d0533a35194bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->